### PR TITLE
Add provider-agnostic AI chat client and server route

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,13 @@
+# set to groq for now; switch to openai_compat later when Meta Llama API is ready
+AI_PROVIDER=groq
+AI_API_KEY=YOUR_API_KEY
+
+# optional (override defaults)
+AI_MODEL=llama-3.3-70b-versatile
+AI_TEMPERATURE=0.65
+AI_MAX_TOKENS=128
+
+# only needed for openai_compat provider (e.g., Meta)
+# AI_PROVIDER=openai_compat
+# AI_API_URL=https://api.llama.com/v1/chat/completions
+# AI_MODEL=llama-3.1-8b-instruct

--- a/lib/ai/env.ts
+++ b/lib/ai/env.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+const toNumber = (v: string | undefined, fallback: number): number =>
+  v ? Number(v) : fallback;
+
+export const AI_PROVIDER = process.env.AI_PROVIDER ?? 'groq'; // 'groq' | 'openai_compat'
+export const AI_API_URL = process.env.AI_API_URL; // required for openai_compat
+export const AI_MODEL = process.env.AI_MODEL; // optional override
+export const AI_API_KEY = process.env.AI_API_KEY!;
+export const AI_TEMPERATURE = toNumber(process.env.AI_TEMPERATURE, 0.65);
+export const AI_MAX_TOKENS = toNumber(process.env.AI_MAX_TOKENS, 128);
+
+export function assertServerEnv(): void {
+  if (!AI_API_KEY) {
+    throw new Error('AI_API_KEY is required.');
+  }
+  if (AI_PROVIDER === 'openai_compat' && !AI_API_URL) {
+    throw new Error('AI_API_URL is required for openai_compat.');
+  }
+}

--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -1,0 +1,45 @@
+import { ChatMessage, ChatOptions, ChatResult, ProviderClient } from './types';
+import { AI_PROVIDER, assertServerEnv } from './env';
+import { GroqClient } from './providers/groq';
+import { OpenAICompatClient } from './providers/openaiCompat';
+
+let client: ProviderClient | null = null;
+
+function getClient(): ProviderClient {
+  if (client) {
+    return client;
+  }
+
+  assertServerEnv();
+  switch (AI_PROVIDER) {
+    case 'groq':
+      client = new GroqClient();
+      break;
+    case 'openai_compat':
+      client = new OpenAICompatClient();
+      break;
+    default:
+      throw new Error(`Unsupported AI_PROVIDER: ${AI_PROVIDER}`);
+  }
+  return client;
+}
+
+function validateMessages(messages: readonly ChatMessage[]): void {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error('chat requires at least one message.');
+  }
+
+  for (const message of messages) {
+    if (!message?.role || !message?.content) {
+      throw new Error('Each message requires a role and content.');
+    }
+  }
+}
+
+export async function chat(
+  messages: readonly ChatMessage[],
+  options?: ChatOptions,
+): Promise<ChatResult> {
+  validateMessages(messages);
+  return getClient().chat(messages, options);
+}

--- a/lib/ai/providers/groq.ts
+++ b/lib/ai/providers/groq.ts
@@ -1,0 +1,54 @@
+import { ChatMessage, ChatOptions, ChatResult, ProviderClient } from '../types';
+import { AI_API_KEY, AI_MODEL, AI_TEMPERATURE, AI_MAX_TOKENS } from '../env';
+
+/** Groq uses an OpenAI-compatible endpoint at:
+ *  https://api.groq.com/openai/v1/chat/completions
+ *  We keep baseURL inline to avoid extra env if provider is known.
+ */
+const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const DEFAULT_MODEL = 'llama-3.3-70b-versatile';
+
+type ChatChoice = {
+  readonly message?: {
+    readonly content?: string;
+  };
+};
+
+type GroqChatResponse = {
+  readonly choices?: readonly ChatChoice[];
+};
+
+export class GroqClient implements ProviderClient {
+  async chat(
+    messages: readonly ChatMessage[],
+    options?: ChatOptions,
+  ): Promise<ChatResult> {
+    const model = options?.model ?? AI_MODEL ?? DEFAULT_MODEL;
+    const temperature = options?.temperature ?? AI_TEMPERATURE;
+    const maxTokens = options?.maxTokens ?? AI_MAX_TOKENS;
+
+    const res = await fetch(GROQ_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        temperature,
+        max_tokens: maxTokens,
+        messages,
+        ...(options?.stop ? { stop: options.stop } : {}),
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Groq error ${res.status}: ${body}`);
+    }
+
+    const data: GroqChatResponse = await res.json();
+    const text = data.choices?.[0]?.message?.content ?? '';
+    return { text };
+  }
+}

--- a/lib/ai/providers/openaiCompat.ts
+++ b/lib/ai/providers/openaiCompat.ts
@@ -1,0 +1,53 @@
+import { ChatMessage, ChatOptions, ChatResult, ProviderClient } from '../types';
+import { AI_API_KEY, AI_API_URL, AI_MODEL, AI_TEMPERATURE, AI_MAX_TOKENS } from '../env';
+
+/** Generic OpenAI-compatible client (e.g., Meta Llama API later).
+ *  Expect a Chat Completions schema at AI_API_URL (e.g. https://api.llama.com/v1/chat/completions)
+ */
+const DEFAULT_MODEL = 'llama-3.1-8b-instruct';
+
+type ChatChoice = {
+  readonly message?: {
+    readonly content?: string;
+  };
+};
+
+type OpenAICompatResponse = {
+  readonly choices?: readonly ChatChoice[];
+};
+
+export class OpenAICompatClient implements ProviderClient {
+  async chat(
+    messages: readonly ChatMessage[],
+    options?: ChatOptions,
+  ): Promise<ChatResult> {
+    const url = AI_API_URL!;
+    const model = options?.model ?? AI_MODEL ?? DEFAULT_MODEL;
+    const temperature = options?.temperature ?? AI_TEMPERATURE;
+    const maxTokens = options?.maxTokens ?? AI_MAX_TOKENS;
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        temperature,
+        max_tokens: maxTokens,
+        messages,
+        ...(options?.stop ? { stop: options.stop } : {}),
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`OpenAI-compat error ${res.status}: ${body}`);
+    }
+
+    const data: OpenAICompatResponse = await res.json();
+    const text = data.choices?.[0]?.message?.content ?? '';
+    return { text };
+  }
+}

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -1,0 +1,21 @@
+export type ChatMessageRole = 'system' | 'user' | 'assistant';
+
+export interface ChatMessage {
+  readonly role: ChatMessageRole;
+  readonly content: string;
+}
+
+export interface ChatOptions {
+  readonly model?: string;
+  readonly temperature?: number;
+  readonly maxTokens?: number;
+  readonly stop?: readonly string[] | undefined;
+}
+
+export interface ChatResult {
+  readonly text: string;
+}
+
+export interface ProviderClient {
+  chat(messages: readonly ChatMessage[], options?: ChatOptions): Promise<ChatResult>;
+}


### PR DESCRIPTION
## Summary
- add shared TypeScript chat types and environment helpers for AI provider selection
- implement Groq and OpenAI-compatible chat clients with normalized responses and validation
- update the interrogate API route to call the new chat helper and handle basic request validation
- document configuration in `.env.local.example` for both Groq and OpenAI-compatible providers

## Testing
- npm run lint *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e236bc0a1c8323818f82164cee89c8