### PR TITLE
Align prompt footer instructions with confession_progress metadata

### DIFF
--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -86,11 +86,14 @@ function parseResponse(text: string): {
 
     try {
       const meta = JSON.parse(jsonStr);
+      const confessionProgressValue =
+        meta.confession_progress ?? meta.confessionProgress ?? 0;
+
       return {
         response: textBeforeJson || 'I have nothing more to say.',
         meta: {
           next_emotion: meta.next_emotion || 'neutral',
-          confession_progress: meta.confession_progress || 0,
+          confession_progress: confessionProgressValue,
         },
       };
     } catch (e) {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -57,7 +57,7 @@ Rules:
 - Always respond IN CHARACTER as ${name.first} ${name.last}.
 - Always include a final JSON footer on a new line:
   {"next_emotion":"one of [neutral,evasive,defensive,anxious,resigned,
-confessing]","confessionProgress":<0-100 integer>}
+confessing]","confession_progress":<0-100 integer>}
 - Confession may ONLY occur when confessionProgress ≥ 96 AND 
 accusationGate === true. Otherwise remain resigned or evasive.
 - If the detective's approach weakens, reduce confessionProgress by 5–15.


### PR DESCRIPTION
## Summary
- update the system prompt footer instructions to require the confession_progress field so it matches our parser and API contract
- add a compatibility fallback in the AI response parser to accept either confession_progress or confessionProgress during rollout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e297ffd0608323b373320afa18b54f